### PR TITLE
Add link to Jobber project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # jobber-docker
-Official Docker images for Jobber
+Official Docker images for [Jobber](https://github.com/dshearer/jobber)


### PR DESCRIPTION
Coming from hub.docker.com, I found this project, but didn't immediately see that there is a separate Jobber project, so you might want to include this link :-)